### PR TITLE
Allow passing args to creation function

### DIFF
--- a/src/Registry/Registry.php
+++ b/src/Registry/Registry.php
@@ -65,13 +65,13 @@ class Registry
      * @return mixed
      * @throws Exception
      */
-    public function get(string $name, bool $fresh = false)
+    public function get(string $name, bool $fresh = false, array $args = [])
     {
         if (!\array_key_exists($name, $this->registry[$this->context]) || $fresh || $this->fresh[$name]) {
             if (!\array_key_exists($name, $this->callbacks)) {
                 throw new Exception('No callback named "' . $name . '" found when trying to create connection');
             }
-            $this->registry[$this->context][$name] = $this->callbacks[$name]();
+            $this->registry[$this->context][$name] = $this->callbacks[$name](...$args);
         }
         
         return $this->registry[$this->context][$name];

--- a/tests/Registry/RegistryTest.php
+++ b/tests/Registry/RegistryTest.php
@@ -43,6 +43,13 @@ class RegistryTest extends TestCase
         $this->assertCount(2, $this->registry->get('array'));
     }
 
+    public function testGetWithParams() {
+        $this->registry->set('param', function ($param) {
+            return $param;
+        });
+        $this->assertEquals('Hello World', $this->registry->get('param', false, ['Hello World']));
+    }
+
     /**
      * @throws \Exception
      */


### PR DESCRIPTION
## What does this PR do

- Allow passing args for the creation function when getting items out of the register

## Test plan

- Added new test for getting with a param